### PR TITLE
Newell/add only to assert tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,15 @@ For more information on what's going on in the background see
 PgDice.partition_table('comments')
 ```
 
+### Copying existing data into new partitions
+
+If you have a table with existing data and you want that data to be split up and copied to your new partitions
+you can use:
+```ruby
+PgDice.partition_table('comments', fill: true)
+```
+
+This will create the partitions and then insert data from the old table into the newly partitioned tables.
 
 ### Notes on partition_table
 

--- a/README.md
+++ b/README.md
@@ -243,6 +243,12 @@ An [InsufficientTablesError](lib/pgdice.rb) will be raised if any conditions are
 This will check that there are 7 future tables from now and that there are 90 past tables
 per our configuration above.
 
+
+If you want to only assert on `past` tables you could use the example below. The same goes for `future`
+```ruby
+PgDice.assert_tables('comments', only: :past)
+```
+
 ## Listing approved tables
 
 Sometimes you might need to know the tables configured for `PgDice`. To list the configured tables 
@@ -252,6 +258,17 @@ PgDice.approved_tables
 ```
 
 The [ApprovedTables](lib/pgdice/approved_tables.rb) object responds to the most common enumerable methods.
+
+
+# Miscellaneous Notes
+
+All methods for `PgDice` take a hash which will override whatever values would have been automatically supplied.
+
+An example of this would be like so: 
+```ruby
+PgDice.list_droppable_partitions('comments', past: 60)
+```
+This example would use `60` instead of the configured value of `90` from the `comments` table we configured above.
 
 
 # FAQ

--- a/lib/pgdice/validation.rb
+++ b/lib/pgdice/validation.rb
@@ -38,16 +38,27 @@ module PgDice
 
     def filter_parameters(table, params)
       if params.nil?
-        params = {}
-        params[:future] = table.future
-        params[:past] = table.past
-        period = table.period
+        params, period = handle_nil_params(table)
       else
+        handle_only_param(table, params) if params[:only]
         period = resolve_period(schema: table.schema, table_name: table.name, **params)
       end
+
       all_params = table.smash(params.merge!(period: period))
 
       [table, period, all_params, params]
+    end
+
+    def handle_nil_params(table)
+      params = {}
+      params[:future] = table.future
+      params[:past] = table.past
+      [params, table.period]
+    end
+
+    def handle_only_param(table, params)
+      params[:future] = params[:only] == :future ? params[:future] || table.future : nil
+      params[:past] = params[:only] == :past ? params[:past] || table.past : nil
     end
 
     def assert_future_tables(table_name, partitions, period, expected)


### PR DESCRIPTION
This should make it much easier for users to control how `assert_tables` behaves as well as fixing a few missing pieces of documentation.