### PR TITLE
fix incorrect handling of months < 10

### DIFF
--- a/lib/pgdice/date_helper.rb
+++ b/lib/pgdice/date_helper.rb
@@ -21,7 +21,7 @@ module PgDice
       when 'year'
         Date.parse("#{date.year}0101")
       when 'month'
-        Date.parse("#{date.year}#{date.month}01")
+        Date.parse("#{date.strftime('%Y%m')}01")
       when 'day'
         date
       else

--- a/test/pgdice/date_helper_test.rb
+++ b/test/pgdice/date_helper_test.rb
@@ -12,13 +12,13 @@ class TableFinderTest < Minitest::Test
   end
 
   def test_safe_date_builder_days
-    table_name = 'comments_20181022'
-    assert_equal Date.parse('20181022'), safe_date_builder(table_name)
+    table_name = 'comments_20180322'
+    assert_equal Date.parse('20180322'), safe_date_builder(table_name)
   end
 
   def test_safe_date_builder_months
-    table_name = 'comments_201810'
-    assert_equal Date.parse('20181001'), safe_date_builder(table_name)
+    table_name = 'comments_201803'
+    assert_equal Date.parse('20180301'), safe_date_builder(table_name)
   end
 
   def test_safe_date_builder_years
@@ -27,15 +27,15 @@ class TableFinderTest < Minitest::Test
   end
 
   def test_truncate_date_day
-    assert_equal Date.parse('20181022'), truncate_date(Date.parse('20181022'), 'day')
+    assert_equal Date.parse('20180322'), truncate_date(Date.parse('20180322'), 'day')
   end
 
   def test_truncate_date_month
-    assert_equal Date.parse('20181001'), truncate_date(Date.parse('20181022'), 'month')
+    assert_equal Date.parse('20180301'), truncate_date(Date.parse('20180322'), 'month')
   end
 
   def test_truncate_date_year
-    assert_equal Date.parse('20180101'), truncate_date(Date.parse('20181022'), 'year')
+    assert_equal Date.parse('20180101'), truncate_date(Date.parse('20180322'), 'year')
   end
 
   def test_truncate_date_invalid_date


### PR DESCRIPTION
Months < 10 would be represented by an integer using the `date.month` method. This meant that when `Date.parse` was called, it used `YYYYnnn` where `n` was the number of days thus far in the year. This behavior is probably not what we want so I switched it to use `strftime` which will always return 2 digit months.