### PR TITLE
Newell/query executor reset

### DIFF
--- a/lib/pgdice.rb
+++ b/lib/pgdice.rb
@@ -42,6 +42,8 @@ require 'pgdice/partition_manager_factory'
 require 'pgdice/partition_dropper'
 require 'pgdice/partition_dropper_factory'
 
+require 'pgdice/query_executor'
+
 require 'pgdice/database_connection'
 require 'pgdice/database_connection_factory'
 

--- a/lib/pgdice.rb
+++ b/lib/pgdice.rb
@@ -43,6 +43,7 @@ require 'pgdice/partition_dropper'
 require 'pgdice/partition_dropper_factory'
 
 require 'pgdice/query_executor'
+require 'pgdice/query_executor_factory'
 
 require 'pgdice/database_connection'
 require 'pgdice/database_connection_factory'

--- a/lib/pgdice/database_connection_factory.rb
+++ b/lib/pgdice/database_connection_factory.rb
@@ -1,21 +1,20 @@
 # frozen_string_literal: true
 
-# Entry point for PartitionManager
+# Entry point
 module PgDice
-  #  PartitionListerFactory is a class used to build PartitionListers
+  #  DatabaseConnectionFactory is a class used to build DatabaseConnections
   class DatabaseConnectionFactory
     extend Forwardable
 
-    def_delegators :@configuration, :logger, :pg_connection, :dry_run
+    def_delegators :@configuration, :logger, :dry_run
 
     def initialize(configuration, opts = {})
       @configuration = configuration
-      @query_executor = opts[:query_executor] ||= PgDice::QueryExecutor.new(logger: logger,
-                                                                            connection_supplier: -> { pg_connection })
+      @query_executor_factory = opts[:query_executor_factory] ||= PgDice::QueryExecutorFactory.new(configuration, opts)
     end
 
     def call
-      PgDice::DatabaseConnection.new(logger: logger, query_executor: @query_executor, dry_run: dry_run)
+      PgDice::DatabaseConnection.new(logger: logger, query_executor: @query_executor_factory.call, dry_run: dry_run)
     end
   end
 end

--- a/lib/pgdice/database_connection_factory.rb
+++ b/lib/pgdice/database_connection_factory.rb
@@ -10,7 +10,8 @@ module PgDice
 
     def initialize(configuration, opts = {})
       @configuration = configuration
-      @query_executor = opts[:query_executor] ||= ->(query) { pg_connection.exec(query) }
+      @query_executor = opts[:query_executor] ||= PgDice::QueryExecutor.new(logger: logger,
+                                                                            connection_supplier: -> { pg_connection })
     end
 
     def call

--- a/lib/pgdice/query_executor.rb
+++ b/lib/pgdice/query_executor.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Entry point for DatabaseConnection
+# Entry point
 module PgDice
   # Wrapper class around pg_connection to reset connection on PG errors
   class QueryExecutor

--- a/lib/pgdice/query_executor.rb
+++ b/lib/pgdice/query_executor.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Entry point for DatabaseConnection
+module PgDice
+  # Wrapper class around pg_connection to reset connection on PG errors
+  class QueryExecutor
+    attr_reader :logger
+
+    def initialize(logger:, connection_supplier:)
+      @logger = logger
+      @connection_supplier = connection_supplier
+    end
+
+    def call(query)
+      @connection_supplier.call.exec(query)
+    rescue PG::Error => error
+      logger.error { "Caught error: #{error}. Going to reset connection and try again" }
+      @connection_supplier.call.reset
+      @connection_supplier.call.exec(query)
+    end
+  end
+end

--- a/lib/pgdice/query_executor_factory.rb
+++ b/lib/pgdice/query_executor_factory.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Entry point
+module PgDice
+  #  QueryExecutorFactory is a class used to build QueryExecutors
+  class QueryExecutorFactory
+    extend Forwardable
+
+    def_delegators :@configuration, :logger, :pg_connection
+
+    def initialize(configuration, opts = {})
+      @configuration = configuration
+      @connection_supplier = opts[:connection_supplier] ||= -> { pg_connection }
+    end
+
+    def call
+      PgDice::QueryExecutor.new(logger: logger, connection_supplier: @connection_supplier)
+    end
+  end
+end

--- a/test/pgdice/query_executor_factory_test.rb
+++ b/test/pgdice/query_executor_factory_test.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class QueryExecutorFactoryTest < Minitest::Test
+  def test_can_generate_query_executor
+    assert PgDice::QueryExecutorFactory.new(PgDice.configuration).call
+  end
+end

--- a/test/pgdice/query_executor_test.rb
+++ b/test/pgdice/query_executor_test.rb
@@ -3,27 +3,37 @@
 require 'test_helper'
 
 class QueryExecutorTest < Minitest::Test
+  def setup
+    @should_raise = true
+    @resetter_call_count = 0
+    @runner_call_count = 0
+
+    @resetter = resetter
+    @runner = runner
+  end
+
   def test_retry_on_pg_error
-    should_raise = true
-
-    resetter_call_count = 0
-    resetter = proc do
-      should_raise = false
-      resetter_call_count += 1
-    end
-
-    runner_call_count = 0
-
-    runner = proc do
-      runner_call_count += 1
-      raise PG::Error, 'Something bad' if should_raise
-    end
-
-    PgDice::QueryExecutor.new(logger: logger, connection_supplier: -> { MockPgConnection.new(runner, resetter) })
+    PgDice::QueryExecutor.new(logger: logger, connection_supplier: -> { MockPgConnection.new(@runner, @resetter) })
                          .call('blah')
 
-    assert_equal 2, runner_call_count, 'Runner should be called twice when we catch a PG error'
-    assert_equal 1, resetter_call_count, 'Resetter should be called once when we catch a PG error'
+    assert_equal 2, @runner_call_count, 'Runner should be called twice when we catch a PG error'
+    assert_equal 1, @resetter_call_count, 'Resetter should be called once when we catch a PG error'
+  end
+
+  private
+
+  def resetter
+    proc do
+      @should_raise = false
+      @resetter_call_count += 1
+    end
+  end
+
+  def runner
+    proc do
+      @runner_call_count += 1
+      raise PG::Error, 'Something bad' if @should_raise
+    end
   end
 end
 

--- a/test/pgdice/query_executor_test.rb
+++ b/test/pgdice/query_executor_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class QueryExecutorTest < Minitest::Test
+  def test_retry_on_pg_error
+    should_raise = true
+
+    resetter_call_count = 0
+    resetter = proc do
+      should_raise = false
+      resetter_call_count += 1
+    end
+
+    runner_call_count = 0
+
+    runner = proc do
+      runner_call_count += 1
+      raise PG::Error, 'Something bad' if should_raise
+    end
+
+    PgDice::QueryExecutor.new(logger: logger, connection_supplier: -> { MockPgConnection.new(runner, resetter) })
+                         .call('blah')
+
+    assert_equal 2, runner_call_count, 'Runner should be called twice when we catch a PG error'
+    assert_equal 1, resetter_call_count, 'Resetter should be called once when we catch a PG error'
+  end
+end
+
+class MockPgConnection
+  def initialize(runner, resetter)
+    @runner = runner
+    @resetter = resetter
+  end
+
+  def exec(query)
+    @runner.call(query)
+  end
+
+  def reset
+    @resetter.call
+  end
+end


### PR DESCRIPTION
Fixes #31 where the logger was being eagerly initialized so new settings were not taking effect.